### PR TITLE
Continue parsing when a syntax error is found

### DIFF
--- a/packages/@glimmer/syntax/lib/parser.ts
+++ b/packages/@glimmer/syntax/lib/parser.ts
@@ -58,15 +58,18 @@ export abstract class Parser {
     >
   > = null;
   public tokenizer: EventedTokenizer;
+  protected continueOnError: boolean;
 
   constructor(
     source: src.Source,
     entityParser = new EntityParser(namedCharRefs),
-    mode: 'precompile' | 'codemod' = 'precompile'
+    mode: 'precompile' | 'codemod' = 'precompile',
+    continueOnError = false,
   ) {
     this.source = source;
     this.lines = source.source.split(/\r\n?|\n/u);
     this.tokenizer = new EventedTokenizer(this, entityParser, mode);
+    this.continueOnError = continueOnError;
   }
 
   offset(): src.SourceOffset {

--- a/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
+++ b/packages/@glimmer/syntax/lib/parser/handlebars-node-visitors.ts
@@ -355,7 +355,15 @@ export abstract class HandlebarsNodeVisitors extends Parser {
     return comment;
   }
 
-  PartialStatement(partial: HBS.PartialStatement): never {
+  PartialStatement(partial: HBS.PartialStatement): unknown { // Error node type
+    if(this.continueOnError) {
+      // return b.error({
+      //   loc: partial.loc,
+      //   error: `Handlebars partials are not supported`
+      // })
+      return null;
+    }
+
     throw generateSyntaxError(
       `Handlebars partials are not supported`,
       this.source.spanFor(partial.loc)

--- a/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
+++ b/packages/@glimmer/syntax/lib/parser/tokenizer-event-handlers.ts
@@ -716,6 +716,7 @@ export interface PreprocessOptions {
     escaping/unescaping of HTML entity codes.
    */
   mode?: 'codemod' | 'precompile' | undefined;
+  continueOnError?: boolean | undefined;
 }
 
 export interface Syntax {
@@ -786,7 +787,7 @@ export function preprocess(
     end: offsets.endPosition,
   };
 
-  let template = new TokenizerEventHandlers(source, entityParser, mode).parse(
+  let template = new TokenizerEventHandlers(source, entityParser, mode, options.continueOnError).parse(
     ast,
     options.locals ?? []
   );

--- a/packages/@glimmer/syntax/lib/v1/handlebars-ast.ts
+++ b/packages/@glimmer/syntax/lib/v1/handlebars-ast.ts
@@ -18,7 +18,7 @@ export interface NodeMap {
   Decorator: { input: Decorator; output: never };
   BlockStatement: { input: BlockStatement; output: ASTv1.BlockStatement | void };
   DecoratorBlock: { input: DecoratorBlock; output: never };
-  PartialStatement: { input: PartialStatement; output: never };
+  PartialStatement: { input: PartialStatement; output: unknown };
   PartialBlockStatement: { input: PartialBlockStatement; output: never };
   ContentStatement: { input: ContentStatement; output: void };
   CommentStatement: { input: CommentStatement; output: ASTv1.MustacheCommentStatement | null };

--- a/packages/@glimmer/syntax/test/parser-node-test.ts
+++ b/packages/@glimmer/syntax/test/parser-node-test.ts
@@ -35,6 +35,15 @@ test('various html element paths', () => {
   }
 });
 
+test('continue parsing after an error', () => {
+  let t = '<img id="one">{{> face}}<img id="two">';
+  astEqual(t, b.template([
+    element('img', ['attrs', ['id', 'one']]),
+    // errorNode('error message'),
+    element('img', ['attrs', ['id', 'two']])
+  ]), undefined, { continueOnError: true });
+});
+
 test('elements can have empty attributes', () => {
   let t = '<img id="">';
   astEqual(t, b.template([element('img', ['attrs', ['id', '']])]));


### PR DESCRIPTION
This PR is far from ready, it simply aims at starting a discussion. 

## Context

When using `ember-template-lint`, any syntax error found throws a `GlimmerSyntaxError` and makes the result of the lint process invalid. On a project I've been working on with @mansona,  we would have needed some sort of "silent mode", a way to be notified about errors without blocking the linter.

The current state of this PR is just a start, and aims at gathering feedbacks about the direction it should take: 
- It takes the `PartialStatement` as an example and doesn't throw when a Handlebars partial is found, and the resulting AST template simply doesn't contain the node.
- The next step would be to build some kind of error node that would have a representation in the resulting AST template.
- Using a new class field for the `Parser` seemed cleaner and less intrusive to me than trying to implement it as parse function's argument.